### PR TITLE
Add last transactions view

### DIFF
--- a/src/components/MultComponents/TransactionList.tsx
+++ b/src/components/MultComponents/TransactionList.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "preact/hooks";
+import { ethers } from "ethers";
+
+interface SimpleTx {
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+}
+
+export default function TransactionList() {
+  const [account, setAccount] = useState<string | null>(null);
+  const [txs, setTxs] = useState<SimpleTx[]>([]);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    if (window.ethereum) {
+      window.ethereum
+        .request({ method: "eth_accounts" })
+        .then((accounts: string[]) => {
+          if (accounts.length > 0) {
+            setAccount(accounts[0]);
+          }
+        })
+        .catch(() => {
+          setError("No se pudo obtener la cuenta");
+        });
+
+      const handleAccountsChanged = (accounts: string[]) => {
+        if (accounts.length > 0) {
+          setAccount(accounts[0]);
+        } else {
+          setAccount(null);
+          setTxs([]);
+        }
+      };
+
+      window.ethereum.on("accountsChanged", handleAccountsChanged);
+      return () => {
+        window.ethereum.off("accountsChanged", handleAccountsChanged);
+      };
+    } else {
+      setError("Por favor, instale Metamask");
+    }
+  }, []);
+
+  useEffect(() => {
+    async function fetchTxs(addr: string) {
+      try {
+        const provider = new ethers.EtherscanProvider(
+          "sepolia",
+          import.meta.env.PUBLIC_ETHERSCAN_API_KEY
+        );
+        const history = await provider.getHistory(addr);
+        const lastFive = history.slice(-5).reverse();
+        const simplified = lastFive.map((tx) => ({
+          hash: tx.hash,
+          from: tx.from,
+          to: tx.to ?? "",
+          value: ethers.formatEther(tx.value),
+        }));
+        setTxs(simplified);
+      } catch (err) {
+        console.error(err);
+        setError("Error al obtener transacciones");
+      }
+    }
+
+    if (account) {
+      fetchTxs(account);
+    }
+  }, [account]);
+
+  if (error) {
+    return <p class="text-red-500">{error}</p>;
+  }
+
+  if (!account) {
+    return <p class="text-yellow-300">Conecte su cuenta en Metamask</p>;
+  }
+
+  if (txs.length === 0) {
+    return <p class="text-gray-400">No hay transacciones recientes</p>;
+  }
+
+  return (
+    <ul class="w-full max-w-xl mt-4 space-y-2">
+      {txs.map((tx) => (
+        <li key={tx.hash} class="border p-2 rounded-lg bg-light dark:bg-dark">
+          <p class="text-xs break-all">
+            <strong>Hash:</strong> {tx.hash}
+          </p>
+          <p class="text-xs break-all">
+            <strong>De:</strong> {tx.from}
+          </p>
+          <p class="text-xs break-all">
+            <strong>Para:</strong> {tx.to}
+          </p>
+          <p class="text-xs">
+            <strong>Valor:</strong> {tx.value} ETH
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/pending.astro
+++ b/src/pages/pending.astro
@@ -6,4 +6,5 @@ import Layout from "../layouts/Layout.astro";
   <div class="flex flex-col items-center justify-center gap-x-4">
     <h1 class="flex flex-row justify-center text-2xl sm:text-3xl font-bold text-black dark:text-white">Pendientes</h1>
     <p class="text-lg text-black dark:text-white">Coming soon</p>
-</Layout> 
+  </div>
+</Layout>

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -7,3 +7,4 @@ import Layout from "../layouts/Layout.astro";
     <h1 class="text-2xl sm:text-3xl font-bold text-black dark:text-white">Settings</h1>
     <p class="text-lg text-black dark:text-white">Coming soon</p>
   </div>
+</Layout>

--- a/src/pages/transactions.astro
+++ b/src/pages/transactions.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import TransactionList from "../components/MultComponents/TransactionList.tsx";
 ---
 
-<Layout title="">
-  <div class="flex flex-col items-center justify-center gap-x-4">
-    <h1 class="text-2xl sm:text-3xl font-bold text-black
-      dark:text-white">Transacciones</h1>
-    <p class="text-lg text-black dark:text-white">Coming soon</p>
+<Layout title="Transacciones recientes">
+  <div class="flex flex-col items-center justify-center gap-x-4 w-full">
+    <h1 class="text-2xl sm:text-3xl font-bold text-black dark:text-white">
+      Transacciones
+    </h1>
+    <TransactionList client:load />
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
- add `TransactionList` component to fetch last transactions from the connected account
- show the history on the transactions page
- clean up other astro pages

## Testing
- `npm install` *(fails: registry.npmjs.org blocked)*
- `npm run build` *(fails: astro not found after failed install)*

------
https://chatgpt.com/codex/tasks/task_e_685873c0aea48329936f80e13a98bea3